### PR TITLE
fix: Use correct target language for on-page translation

### DIFF
--- a/content/content_bundle.js
+++ b/content/content_bundle.js
@@ -479,10 +479,10 @@ const handleMouseUp = async (event) => {
       if (selection && selection.rangeCount > 0) {
         try {
           if (chrome && chrome.storage && chrome.storage.local) {
-            const { textTargetLanguage } = await chrome.storage.local.get(["textTargetLanguage"]);
+            const { selectedTextLanguage } = await chrome.storage.local.get(["selectedTextLanguage"]);
             updateState({
               selectedText,
-              targetLanguage: textTargetLanguage || "English"
+              targetLanguage: selectedTextLanguage || "English"
             });
           } else {
             updateState({


### PR DESCRIPTION
This commit fixes an issue where the on-page text selection translation was not using the language selected in the extension's settings.

The content script was using the `textTargetLanguage` key, which is intended for the popup translation, instead of the `selectedTextLanguage` key, which is intended for on-page translation. This has been corrected to use the `selectedTextLanguage` key, ensuring that on-page translations respect the user's settings.